### PR TITLE
Use the latest 0.2.xx version of kafka-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "assert-plus": "0.1.5",
     "bunyan": "1.4.0",
-    "kafka-node": "0.2.27"
+    "kafka-node": "~0.2.27"
   },
   "devDependencies": {
     "chai": "^3.0.0",


### PR DESCRIPTION
The 0.2.27 version of kafka-node depends on snappy-3.2.2, which is not compatible with newer versions of node.js (fails to compile).  The latest version of kafka node as of right now is 0.2.29, which uses snappy 4.0.1, which does compile with newer versions of node.js

On my machine with the vanilla kafka-node, make test fails with a compilation error trying to resolve dependencies.  But after changing package.json to require the latest 0.2.xx version it resolves to 0.2.29 and the test still runs.

If you'd prefer to avoid tilde dependencies we could always bump the kafka-node version to 0.2.29 directly.
